### PR TITLE
Add additional conversion options for eggs/tsp/tbsp

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,16 +1,14 @@
 import { useState, useEffect } from "react";
 
+import { SelectedOptionsType } from "./types";
+
 import Footer from "./components/Footer";
 import Header from "./components/Header";
 import InputRecipe from "./components/InputRecipe";
 import Intro from "./components/Intro";
 import OutputRecipe from "./components/OutputRecipe";
 
-// target unit from dropdown - initially just use grams
-// have a simple "to metric" option?
-// Have a button "convert eggs" if eggs are detected in the text? Most people probably don't want the eggs in grams.
-// have a button to convert teaspoons/tablespoons or leave them as they are
-// for ounces, don't parse or convert them, just do an inplace replace.
+// TO DO: target unit from dropdown - initially just use grams
 
 const App = () => {
   // ¾ cup all-purpose flour
@@ -27,8 +25,13 @@ const App = () => {
   // 1 tsp vanilla extract
   // dash of granulated sugar
 
+  const [converting, setConverting] = useState(false);
   const [errorMsg, setErrorMsg] = useState("");
   const [pastedRecipe, setPastedRecipe] = useState("");
+  const [selectedOptions, setSelectedOptions] = useState<SelectedOptionsType>({
+    eggs: false,
+    tsp: false
+  });
 
   useEffect(() => {
     console.log(pastedRecipe);
@@ -39,7 +42,11 @@ const App = () => {
       <Header />
       <Intro />
       <div className="recipe-section">
-        <InputRecipe setPastedRecipe={setPastedRecipe} />
+        <InputRecipe
+          setPastedRecipe={setPastedRecipe} 
+          setSelectedOptions={setSelectedOptions}
+          setConverting={setConverting}
+        />
 
         {errorMsg && 
           <div className="recipe-error-container">
@@ -51,7 +58,10 @@ const App = () => {
         }
         
         <OutputRecipe 
+          converting={converting}
           pastedRecipe={pastedRecipe} 
+          selectedOptions={selectedOptions}
+          setConverting={setConverting}
           setErrorMsg={setErrorMsg}
         />
       </div>

--- a/src/components/ConversionOptions.tsx
+++ b/src/components/ConversionOptions.tsx
@@ -1,0 +1,39 @@
+import { SelectedOptionsType } from '../types';
+
+type ConversionOptionsProps = {
+  setSelectedOptions: Function
+}
+
+
+const ConversionOptions = ({ setSelectedOptions }: ConversionOptionsProps) => {
+  const handleSelectedOptions = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setSelectedOptions((prevOptions: SelectedOptionsType) => {
+      return { ...prevOptions, [e.target.id]: e.target.checked}
+    })
+  }
+
+  return (
+    <div className="conversion-options-container">
+      <label className="conversion-option-label">
+        Convert eggs
+        <input
+          className="conversion-option-checkbox"
+          id="eggs"
+          onChange={handleSelectedOptions}
+          type="checkbox"
+        />
+      </label>
+      <label className="conversion-option-label">
+        Convert teaspoons, tablespoons, etc
+        <input
+          className="conversion-option-checkbox"
+          id="tsp"
+          onChange={handleSelectedOptions}
+          type="checkbox"
+        />
+      </label>
+    </div>
+  )
+}
+
+export default ConversionOptions;

--- a/src/components/InputRecipe.tsx
+++ b/src/components/InputRecipe.tsx
@@ -1,15 +1,20 @@
-import { useRef } from 'react';
+import { FunctionComponent, useRef } from 'react';
+
+import ConversionOptions from './ConversionOptions';
 
 type InputRecipeProps = {
-  setPastedRecipe: Function
+  setPastedRecipe: Function,
+  setConverting: Function,
+  setSelectedOptions: Function
 }
 
-const InputRecipe = ({ setPastedRecipe }: InputRecipeProps) => {
+const InputRecipe = ({ setPastedRecipe, setConverting, setSelectedOptions }: InputRecipeProps) => {
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
   const handleSetRecipe: () => void = () => {
     if (textareaRef.current) {
       setPastedRecipe(textareaRef.current.value);
+      setConverting(true);
     }
   }
 
@@ -17,6 +22,7 @@ const InputRecipe = ({ setPastedRecipe }: InputRecipeProps) => {
     <>
       <h3 className="recipe-title">Paste or type your recipe below:</h3>
       <textarea className="recipe-container input-recipe-container" ref={textareaRef} />
+      <ConversionOptions setSelectedOptions={setSelectedOptions} />
       <button className="btn-convert" onClick={handleSetRecipe}>
         <span>Convert!</span>
       </button>

--- a/src/scss/_recipe.scss
+++ b/src/scss/_recipe.scss
@@ -46,6 +46,30 @@
   }
 }
 
+.conversion-options-container {
+  font-family: "SimplePlan";
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  flex-wrap: wrap;
+  width: 100%;
+  gap: 3rem;
+  padding: 1.5rem 0;
+}
+
+.conversion-option-label {
+  display: flex;
+  gap: 0.75rem;
+  font-size: 1.5rem;
+  -webkit-user-select: none;
+          user-select: none;
+  cursor: pointer;
+}
+
+.conversion-option-checkbox {
+  width: 1.25rem;
+}
+
 // After conversion
 .output-recipe-section-container {
   font-family: "SimplePlan";

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,3 @@
+export type SelectedOptionsType = {
+  [key: string]: boolean;
+};


### PR DESCRIPTION
- Add checkboxes so that users can decide if they want to leave eggs, teaspoons, tablespoons, etc. unconverted
- Add `converting` state so that users can tick/untick checkboxes and reconvert if they wish (even though the text has not changed)