### PR TITLE
Make conversion options responsive, refactor variants

### DIFF
--- a/src/components/ConversionOptions.tsx
+++ b/src/components/ConversionOptions.tsx
@@ -24,7 +24,7 @@ const ConversionOptions = ({ setSelectedOptions }: ConversionOptionsProps) => {
         />
       </label>
       <label className="conversion-option-label">
-        Convert teaspoons, tablespoons, etc
+        {window.innerWidth > 380 ? "Convert teaspoons, tablespoons, etc." : "Convert tea/tablespoons, etc."}
         <input
           className="conversion-option-checkbox"
           id="tsp"

--- a/src/scss/_media.scss
+++ b/src/scss/_media.scss
@@ -148,6 +148,11 @@
     font-size: 1.3rem;
   }
 
+  .conversion-option-label {
+    gap: 0.5rem;
+    font-size: 1.3rem;
+  }
+
   .btn-convert {
     font-size: 2rem;
     padding: 0.25rem 1.5rem;
@@ -176,6 +181,10 @@
   .intro-text {
     font-size: 1.4rem;
     text-align: center;
+  }
+  
+  .recipe-section {
+    margin: 0 auto 2rem auto;
   }
 
   .recipe-title {

--- a/src/scss/_recipe.scss
+++ b/src/scss/_recipe.scss
@@ -53,7 +53,7 @@
   justify-content: flex-start;
   flex-wrap: wrap;
   width: 100%;
-  gap: 3rem;
+  gap: 0.5rem 3rem;
   padding: 1.5rem 0;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,18 @@
 export type SelectedOptionsType = {
   [key: string]: boolean;
 };
+
+export type RecipeLineType = {
+  amount: number,
+  unit: string,
+  name: string,
+}
+
+export type OutputRecipeFormat = {
+  answer: string,
+  sourceAmount: number,
+  sourceUnit: string,
+  targetAmount: number,
+  targetUnit: string,
+  type: "CONVERSION"
+}


### PR DESCRIPTION
- Refactor egg and measuring spoon variants into their own functions to make it cleaner and more readable to detect when these functions should be called
- Make the conversion options checkboxes responsive down to 330px