### PR TITLE
Add functionality to convert to cups

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,9 @@
 import { useState, useEffect } from "react";
 
-import { SelectedOptionsType } from "./types";
+import { 
+  ConvertToType,
+  SelectedOptionsType 
+} from "./types";
 
 import Footer from "./components/Footer";
 import Header from "./components/Header";
@@ -8,24 +11,9 @@ import InputRecipe from "./components/InputRecipe";
 import Intro from "./components/Intro";
 import OutputRecipe from "./components/OutputRecipe";
 
-// TO DO: target unit from dropdown - initially just use grams
-
 const App = () => {
-  // ¾ cup all-purpose flour
-  // ¼ cup granulated sugar
-  // ¾ teaspoon ground cinnamon
-  // ⅛ teaspoon salt
-  // ¼ cup + 2 Tablespoons of milk
-  // ¼ cup + 2 teaspoons vegetable or canola oil
-  // ½ teaspoons ground cinnamon   
-  // 16 oz. cream cheese, room temperature
-  // 2 eggs, whites and yolks separated at room temperature
-  // 3/4 c. granulated sugar
-  // 1/2 tsp salt
-  // 1 tsp vanilla extract
-  // dash of granulated sugar
-
   const [converting, setConverting] = useState(false);
+  const [convertTo, setConvertTo] = useState<ConvertToType>("grams");
   const [errorMsg, setErrorMsg] = useState("");
   const [pastedRecipe, setPastedRecipe] = useState("");
   const [selectedOptions, setSelectedOptions] = useState<SelectedOptionsType>({
@@ -43,9 +31,11 @@ const App = () => {
       <Intro />
       <div className="recipe-section">
         <InputRecipe
+          convertTo={convertTo}
           setPastedRecipe={setPastedRecipe} 
           setSelectedOptions={setSelectedOptions}
           setConverting={setConverting}
+          setConvertTo={setConvertTo}
         />
 
         {errorMsg && 
@@ -59,6 +49,7 @@ const App = () => {
         
         <OutputRecipe 
           converting={converting}
+          convertTo={convertTo}
           pastedRecipe={pastedRecipe} 
           selectedOptions={selectedOptions}
           setConverting={setConverting}

--- a/src/components/ConversionOptions.tsx
+++ b/src/components/ConversionOptions.tsx
@@ -1,7 +1,7 @@
 import { SelectedOptionsType } from '../types';
 
 type ConversionOptionsProps = {
-  setSelectedOptions: Function
+  setSelectedOptions: React.Dispatch<React.SetStateAction<SelectedOptionsType>>
 }
 
 

--- a/src/components/ConversionUnit.tsx
+++ b/src/components/ConversionUnit.tsx
@@ -1,0 +1,22 @@
+import { ConvertToType } from "../types";
+
+type ConversionUnitProps = {
+  convertTo: ConvertToType,
+  setConvertTo: React.Dispatch<React.SetStateAction<ConvertToType>>
+}
+
+const ConversionUnit = ({ convertTo, setConvertTo }: ConversionUnitProps) => {
+  const handleSetConvertTo = () => {
+    setConvertTo((prevUnit: ConvertToType) => prevUnit === "grams" ? "cups" : "grams");
+  }
+
+  return (
+    <div className="conversion-dropdown-container" onClick={handleSetConvertTo}>
+      <div className={`conversion-dropdown ${convertTo === "grams" ? "conversion-dropdown-grams" : "conversion-dropdown-cups"}`}>
+        {convertTo}
+      </div>
+    </div>
+  )
+}
+
+export default ConversionUnit;

--- a/src/components/InputRecipe.tsx
+++ b/src/components/InputRecipe.tsx
@@ -1,14 +1,22 @@
-import { FunctionComponent, useRef } from 'react';
+import { useRef } from 'react';
+
+import { 
+  ConvertToType,
+  SelectedOptionsType
+} from '../types';
 
 import ConversionOptions from './ConversionOptions';
+import ConversionUnit from './ConversionUnit';
 
 type InputRecipeProps = {
-  setPastedRecipe: Function,
-  setConverting: Function,
-  setSelectedOptions: Function
+  convertTo: ConvertToType
+  setPastedRecipe: React.Dispatch<React.SetStateAction<string>>,
+  setConverting: React.Dispatch<React.SetStateAction<boolean>>,
+  setConvertTo: React.Dispatch<React.SetStateAction<ConvertToType>>,
+  setSelectedOptions: React.Dispatch<React.SetStateAction<SelectedOptionsType>>
 }
 
-const InputRecipe = ({ setPastedRecipe, setConverting, setSelectedOptions }: InputRecipeProps) => {
+const InputRecipe = ({ convertTo, setPastedRecipe, setConverting, setConvertTo, setSelectedOptions }: InputRecipeProps) => {
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
   const handleSetRecipe: () => void = () => {
@@ -23,6 +31,13 @@ const InputRecipe = ({ setPastedRecipe, setConverting, setSelectedOptions }: Inp
       <h3 className="recipe-title">Paste or type your recipe below:</h3>
       <textarea className="recipe-container input-recipe-container" ref={textareaRef} />
       <ConversionOptions setSelectedOptions={setSelectedOptions} />
+      <div className="conversion-units-container">
+        <div className="conversion-units-text">Converting into</div>
+        <ConversionUnit 
+          convertTo={convertTo}
+          setConvertTo={setConvertTo}
+        />
+      </div>
       <button className="btn-convert" onClick={handleSetRecipe}>
         <span>Convert!</span>
       </button>

--- a/src/scss/_recipe.scss
+++ b/src/scss/_recipe.scss
@@ -70,6 +70,40 @@
   width: 1.25rem;
 }
 
+.conversion-units-container {
+  display: flex;
+  gap: 0.5rem;
+  margin-top: 1rem;
+}
+
+.conversion-units-text {
+  font-family: "SimplePlan";
+  font-size: 1.75rem;
+}
+
+.conversion-dropdown-container {
+  min-width: 4rem;
+}
+
+.conversion-dropdown {
+  font-family: "SimplePlan";
+  font-size: 1.75rem;
+  border-bottom: 2px solid $color-primary;
+  text-align: center;
+  cursor: pointer;
+  -webkit-user-select: none;
+          user-select: none;
+}
+
+.conversion-dropdown-grams {
+  color: $color-secondary;
+  border-color: $color-secondary;
+}
+
+.conversion-dropdown-cups {
+  color: $color-primary;
+}
+
 // After conversion
 .output-recipe-section-container {
   font-family: "SimplePlan";

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,3 +16,5 @@ export type OutputRecipeFormat = {
   targetUnit: string,
   type: "CONVERSION"
 }
+
+export type ConvertToType = "cups" | "grams";

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -1,0 +1,38 @@
+export const convertCupsToFraction = (amount: number) => {
+  let recipeLine = "";
+
+  const integer = Math.floor(amount);
+  // round remaining decimal to nearest 1/8 or 1/3 as cups are multiples of either 1/8 or 1/3
+  const fractionToNearestEighth = Math.round((amount - integer) * 8) / 8;
+  const fractionToNearestThird = Math.round((amount - integer) * 3) / 3;
+
+  // find out whether the nearest eighth or third is closest to the decimal input
+  const closestFraction = Math.abs(fractionToNearestThird - amount) < Math.abs(fractionToNearestEighth - amount)
+    ? fractionToNearestThird
+    : fractionToNearestEighth
+
+  if (closestFraction === 0) {
+    recipeLine = `${integer} cups`;
+  }
+
+  let denominator = closestFraction === fractionToNearestEighth ? 8 : 3;
+  let numerator = Math.round(closestFraction * denominator);
+
+  // use Euclidean algorithm to get highest common factor of numerator and denominator
+  function highestCommonFactor(numerator: number, denominator: number) {
+    while (denominator !== 0) {
+      let remainder = numerator % denominator;
+      numerator = denominator;
+      denominator = remainder;
+    }
+    // Return the last non-zero remainder as the highest common factor
+    return numerator;
+  }
+
+  let divisor = highestCommonFactor(numerator, denominator);
+  numerator /= divisor;
+  denominator /= divisor;
+
+  let fraction = integer ? `${integer} ${numerator}/${denominator}` : `${numerator}/${denominator}`; 
+  return integer > 1 ? `${fraction} cups` : `${fraction} cup`;
+}


### PR DESCRIPTION
- Add functionality so that recipes can be converted to cups as well as to grams
- Implement a function that ensures only multiples of 1/8 or 1/3 can be used for cups, because generally cups exist in multiples of 1/8, 1/4, 1/3 or 1/2 - so the conversion will never generate an output of 2/17 of a cup, for example
- Update the setState props so that they are of the correct type instead of the placeholder `Function`