### PR TITLE
Fix bug with plural units, remove non-alphanumeric chars

### DIFF
--- a/src/components/OutputRecipe.tsx
+++ b/src/components/OutputRecipe.tsx
@@ -60,7 +60,15 @@ const OutputRecipe = ({ converting, convertTo, pastedRecipe, selectedOptions, se
 
     const recipeLinesToFetch = pastedRecipe
       .split("\n")
-      .map((row: string) => row.trim())
+      .map((row: string) => {
+        // If the first character of the line is not a number, slice from the first num
+        if (isNaN(Number(row[0]))) {
+          const rowArr = row.split("");
+          const firstNum = rowArr.findIndex(char => !isNaN(Number(char)) && char !== " ");
+          return row.slice(firstNum).trim();
+        }
+        return row;
+      })
       .filter((row: string) => row)
       // replace any unicode fraction characters with normalized strings
       .map((row: string) => row.normalize("NFKD").replaceAll("▢", ""))

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -22,8 +22,11 @@ function highestCommonFactor(numerator: number, denominator: number) {
   return numerator;
 }
 
-  export const decimalToFraction = (amount: number, unit: string = "cup") => {
+export const decimalToFraction = (amount: number, unit: string = "cup") => {
+  // If 'cups' or 'grams' are passed in, ensure they become singular
+  if (unit.endsWith("s")) unit = unit.slice(0, unit.length - 1);
   const integer = Math.floor(amount);
+  
   // round remaining decimal to nearest 1/8 or 1/3 as cups are multiples of either 1/8 or 1/3
   const fractionToNearestEighth = Math.round((amount - integer) * 8) / 8;
   const fractionToNearestThird = Math.round((amount - integer) * 3) / 3;
@@ -45,6 +48,6 @@ function highestCommonFactor(numerator: number, denominator: number) {
   numerator /= divisor;
   denominator /= divisor;
 
-  let fraction = integer ? `${integer} ${numerator}/${denominator}` : `${numerator}/${denominator}`; 
+  let fraction = integer ? `${integer} ${numerator}/${denominator}` : `${numerator}/${denominator}`;
   return integer > 1 ? `${fraction} ${unit}s` : `${fraction} ${unit}`;
 }


### PR DESCRIPTION
- Fix bug with the units being passed to `decimalToFraction()` being plural - the units are dynamically pulled from the API response so may be singular or plural
- Remove non-alphanumeric characters from the beginning of the recipe line causing it to be parsed incorrectly (e.g. "▢ 250 g flour" is now parsed the same as "250g flour")